### PR TITLE
Explictly ask CircleCI to run release_on_github on all tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,8 @@ workflows:
           filters:
             branches:
               ignore: /.*/
+            tags:
+              only: /.*/
           requires:
             - test_library
             - test_demo


### PR DESCRIPTION
CircleCi does not run workflows on tags unless
explicitly asked to do so.