### PR TITLE
Remove -v from curl calls on release script

### DIFF
--- a/.circleci/release_github.sh
+++ b/.circleci/release_github.sh
@@ -14,7 +14,6 @@ uploadReleaseToGitHub() {
 
   # Create the release in GitHub and extract its id from the response
   RESPONSE_BODY=$(curl -s \
-    -v \
     -u "${CIRCLE_USERNAME}":"${GITHUB_TOKEN}" \
     --header "Accept: application/vnd.github.v3+json" \
     --header "Content-Type: application/json; charset=utf-8" \
@@ -30,7 +29,6 @@ uploadReleaseToGitHub() {
   # Attach library
   LIBRARY_UPLOAD_URL=$(echo ${UPLOAD_URL} | sed "s/{?name,label}/?name=library-${THIS_TAG}.aar/")
   curl -s \
-    -v \
     -u "${CIRCLE_USERNAME}":"${GITHUB_TOKEN}" \
     --header "Accept: application/vnd.github.v3+json" \
     --header "Content-Type: application/zip" \
@@ -43,7 +41,6 @@ uploadReleaseToGitHub() {
   # Attach demo
   DEMO_UPLOAD_URL=$(echo ${UPLOAD_URL} | sed "s/{?name,label}/?name=demo-${THIS_TAG}.apk/")
   curl -s \
-    -v \
     -u "${CIRCLE_USERNAME}":"${GITHUB_TOKEN}" \
     --header "Accept: application/vnd.github.v3+json" \
     --header "Content-Type: application/zip" \


### PR DESCRIPTION
They were leaking the deployment token.